### PR TITLE
Support debug on any port

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ supports loading javascript and coffee-script modules.
 * `--no-brk` prevents a breakpoint to be added on the first line of the script
 * `--chrome` opens Chrome with the correct URL to start debugging
 * `--webhost`, `--webport` specifiy where the webserver with inspector will be listening
+* `--debugport` to let the debug session run over a port different from 5858
 
 ## Status and warnings
 
@@ -48,9 +49,6 @@ supports loading javascript and coffee-script modules.
 * `require` doesn't work in the console, it maybe should be more repl-like
 * A lot of stuff is just dumped to console.log - proper logging would be nice I guess
 * Generally the code shows that it's a prototype - code quality, test coverage, ...
-* Debugger is running on port 5858. So running more than one debug session is currently not
-  possible. I'm using the IPC channel between the script- and the bugger-process, didn't find
-  yet how to change the debug port without using the node CLI option.
 * LiveEdit is pretty certainly not working
 * The websocket connection isn't really stable
 * Memory usage monitoring is running inside of the script thread. Maybe it would be better to

--- a/lib/argv.js
+++ b/lib/argv.js
@@ -27,6 +27,10 @@ argvParser = require('optimist').usage('bugger [OPTIONS] FILE_NAME').options({
   webport: {
     'default': 8058,
     describe: 'Web port used by node-inspector'
+  },
+  debugport: {
+    'default': 5858,
+    describe: 'Remote debugger port used by node'
   }
 });
 argv = argvParser.argv;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,13 +6,14 @@ debugClient = require('./debug-client');
 inspectorServer = require('./inspector/server');
 Module = require('module');
 run = function () {
-  var _chromeProc, _entryScriptProc, appUrl, argv, brk, cache$, chrome, entryScript, entryScriptArg, scriptArgs, webhost, webport;
+  var _chromeProc, _entryScriptProc, appUrl, argv, brk, cache$, chrome, debugPort, entryScript, entryScriptArg, scriptArgs, webhost, webport;
   argv = require('./argv');
   cache$ = argv;
   chrome = cache$.chrome;
   brk = cache$.brk;
   webhost = cache$.webhost;
   webport = cache$.webport;
+  debugPort = argv.debugport;
   require('./lang');
   entryScriptArg = argv._.shift();
   entryScript = function () {
@@ -73,7 +74,8 @@ run = function () {
   return forkEntryScript({
     entryScript: entryScript,
     scriptArgs: scriptArgs,
-    brk: brk
+    brk: brk,
+    debugPort: debugPort
   }, function (param$) {
     var cache$1, debugConnection, entryScriptProc;
     {

--- a/lib/forked/entry_script.js
+++ b/lib/forked/entry_script.js
@@ -39,7 +39,8 @@ commands = {
   }
 };
 if (!(null != module.parent)) {
-  process.kill(process.pid, 'SIGUSR1');
+  process.debugPort = process.env.BUGGER_DEBUG_PORT;
+  process._debugProcess(process.pid);
   process.on('message', function (message) {
     if (null != commands[message.method]) {
       return commands[message.method](message);
@@ -75,11 +76,12 @@ EntryScriptWrapper = function (super$) {
     }, params));
   };
   EntryScriptWrapper.prototype.forkEntryScript = function (param$, cb) {
-    var backChannelHandlers, brk, cache$, cache$1, entryScript, entryScriptProc, fork, net, networkAgent, scriptArgs, spawn, startupFailedTimeout;
+    var backChannelHandlers, brk, cache$, cache$1, debugPort, entryScript, entryScriptProc, env, fork, net, networkAgent, scriptArgs, spawn, startupFailedTimeout;
     {
       cache$ = param$;
       entryScript = cache$.entryScript;
       scriptArgs = cache$.scriptArgs;
+      debugPort = cache$.debugPort;
       brk = cache$.brk;
     }
     cache$1 = require('child_process');
@@ -87,7 +89,11 @@ EntryScriptWrapper = function (super$) {
     fork = cache$1.fork;
     net = require('net');
     networkAgent = require('../agents/network');
-    entryScriptProc = fork(module.filename, scriptArgs, { silent: true });
+    env = _.defaults({ BUGGER_DEBUG_PORT: debugPort }, process.env);
+    entryScriptProc = fork(module.filename, scriptArgs, {
+      env: env,
+      silent: true
+    });
     startupFailedTimeout = setTimeout(function () {
       throw new Error('Process for entry script failed to start');
     }, 1e3);
@@ -98,7 +104,7 @@ EntryScriptWrapper = function (super$) {
         if (startupFailedTimeout)
           clearTimeout(startupFailedTimeout);
         startupFailedTimeout = true;
-        return debugConnection = net.connect(5858, function () {
+        return debugConnection = net.connect(debugPort, function () {
           entryScriptProc.send({
             method: 'startScript',
             entryScript: entryScript,

--- a/src/argv.coffee
+++ b/src/argv.coffee
@@ -24,6 +24,9 @@ argvParser = require('optimist')
   webport:
     default: 8058
     describe: 'Web port used by node-inspector'
+  debugport:
+    default: 5858
+    describe: 'Remote debugger port used by node'
 )
 
 argv = argvParser.argv

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -13,6 +13,7 @@ Module = require 'module'
 run = ->
   argv = require './argv'
   {chrome, brk, webhost, webport} = argv
+  debugPort = argv['debugport']
 
   # Make sure node knows about the additional script parsers
   require './lang'
@@ -52,7 +53,7 @@ run = ->
       console.log '[bugger] Chrome closed, exiting...'
       process.exit 0
 
-  forkEntryScript {entryScript, scriptArgs, brk}, ({entryScriptProc, debugConnection}) ->
+  forkEntryScript {entryScript, scriptArgs, brk, debugPort}, ({entryScriptProc, debugConnection}) ->
     _entryScriptProc = entryScriptProc
     _entryScriptProc.on 'exit', ->
       console.log '[bugger] Script finished, exiting...'


### PR DESCRIPTION
Previously the port 5858 was hard coded. It was changed to use `process.debugPort` to specify which port to listen on.
