### PR TITLE
Pretty-print /json/* responses

### DIFF
--- a/lib/io-thread/index.js
+++ b/lib/io-thread/index.js
@@ -40,9 +40,9 @@ const server = http.createServer((req, res) => {
       'Protocol-Version': '1.1',
       'User-Agent': 'Node/' + process.version + ' v8' + process.versions.v8,
       'WebKit-Version': '537.36 (@181352)',
-    }));
+    }, null, 2));
   } else if (req.url === '/json') {
-    return res.end(JSON.stringify([ page ]));
+    return res.end(JSON.stringify([ page ], null, 2));
   } else if (req.url === '/json/activate/' + pageId) {
     return res.end('"Target activated"');
   }


### PR DESCRIPTION
Currently, the JSON responses are one liners, which makes it hard to
read.

This adds two spaces of indentation to the responses.