### PR TITLE
Add /json/list as an alias for /json

### DIFF
--- a/lib/io-thread/index.js
+++ b/lib/io-thread/index.js
@@ -41,7 +41,7 @@ const server = http.createServer((req, res) => {
       'User-Agent': 'Node/' + process.version + ' v8' + process.versions.v8,
       'WebKit-Version': '537.36 (@181352)',
     }));
-  } else if (req.url === '/json') {
+  } else if (req.url === '/json' || req.url === '/json/list') {
     return res.end(JSON.stringify([ page ]));
   } else if (req.url === '/json/activate/' + pageId) {
     return res.end('"Target activated"');


### PR DESCRIPTION
The chrome debugging server supports both /json and /json/list to
retrive the list of available debugging targets.

This adds /json/list as an alias for /json.