### PR TITLE
Use the script filename as the page url

### DIFF
--- a/lib/bugger.js
+++ b/lib/bugger.js
@@ -5,7 +5,7 @@ const Agents = require('./agents');
 
 function startDebug(config) {
   const thread = createThread(require.resolve('./io-thread'),
-    [ '' + config.port ]);
+    [ '' + config.port, config.filename ]);
   const agents = new Agents(thread);
   return agents;
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -40,7 +40,9 @@ if (config.version) {
   process.exit(config.help ? 0 : 1);
 }
 
+config.filename = config._[0];
 const resolvedArgv = require.resolve(path.resolve(process.cwd(), config._.shift()));
+
 process.argv = [ process.argv[0], resolvedArgv ].concat(config._);
 
 const agents = startDebug(config);

--- a/lib/io-thread/index.js
+++ b/lib/io-thread/index.js
@@ -6,8 +6,10 @@ const EventEmitter = require('events').EventEmitter;
 
 const debug = require('debug')('bugger:io-thread');
 const WebSocketServer = require('ws').Server;
+const path = require('path');
 
 const port = process.argv[2];
+const filename = process.argv[3];
 
 const threadEvents = new EventEmitter();
 thread.onMessage = function onMessage(message) {
@@ -27,7 +29,7 @@ const page = {
   id: pageId,
   title: process.title,
   type: 'page',
-  url: 'file://' + process.mainModule.filename,
+  url: 'file://' + path.resolve(filename),
   webSocketDebuggerUrl: 'ws://' + ws,
 };
 


### PR DESCRIPTION
Currently the page url is reported as the path to the io-thread module
in bugger (fixes #53)

This forwards the input filename through the config object and sets it
as the page url.