### PR TITLE
Reverse engineer and fix timeline tab

### DIFF
--- a/example/tracing/index.js
+++ b/example/tracing/index.js
@@ -1,0 +1,125 @@
+'use strict'; /* eslint no-console:0 */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const http = require('http');
+
+const express = require('express');
+const _ = require('lodash');
+const request = require('request');
+
+const port = 3000;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const INVALID_URI = 'http://10.255.255.1';
+
+const app = express();
+
+app.get('/hello', (req, res) => {
+  res.json({ message: 'Hello World!' });
+});
+
+app.get('/big', (req, res) => {
+  const blob = new Buffer(128 + ((Math.random() * 4096) | 0)).fill('x').toString();
+  res.json({ blob, message: `Returned ${blob.length} bytes` });
+});
+
+app.get('/fail', (req) => {
+  req.socket.destroy();
+});
+
+app.get('/silly-io', (req, res, next) => {
+  let error;
+  try {
+    require('./throws');
+  } catch (e) {
+    error = e;
+  }
+  if (error) {
+    return next(error);
+  }
+  res.json({ message: 'Well, this is unexpected...' });
+});
+
+app.get('/delays', (req, res, next) => {
+  const hash = crypto.createHash('sha1');
+
+  function sendChecksum(sha) {
+    res.json({ filename: __filename, message: sha });
+  }
+
+  function loadOtherFile() {
+    const readStream = fs.createReadStream('package.json');
+    readStream.on('error', next);
+    readStream.on('data', chunk => hash.update(chunk));
+    readStream.on('end', () =>
+      setImmediate(sendChecksum, hash.digest('hex')));
+  }
+
+  function loadFile() {
+    const readStream = fs.createReadStream(__filename);
+    readStream.on('error', next);
+    readStream.on('data', chunk => hash.update(chunk));
+    readStream.on('end', () => process.nextTick(loadOtherFile));
+  }
+
+  setTimeout(loadFile, Math.random() * 50 | 0);
+});
+
+app.get('/fib', (req, res) => {
+  function terribleFib(x) {
+    // Worst fib possible. We are trying to be awful.
+    if (x < 2) return 1;
+    return terribleFib(x - 2) + terribleFib(x - 1);
+  }
+  const n = 10 + Math.floor(Math.random() * 29); // max 38
+  const start = process.hrtime();
+  const fib = terribleFib(n);
+  const dur = process.hrtime(start);
+
+  function formatDur(pair) {
+    return pair[0] * 1e3 + pair[1] / 1e6;
+  }
+  res.json({
+    n, 'fib(n)': fib, dur,
+    message: `fib(${n}) = ${fib} [ took ${formatDur(dur)}ms ]`,
+  });
+});
+
+app.use((req, res) => {
+  res.statusCode = 404;
+  res.json({ message: 'Not found', url: req.url });
+});
+
+app.use((error, req, res, next) => {
+  /* eslint no-unused-vars:0 */
+  res.statusCode = 500;
+  res.json({ message: error.message });
+});
+
+function runRequestor() {
+  const pathname = _.sample([
+    null,
+    '/hello',
+    '/big',
+    '/silly-io',
+    '/fail',
+    '/delays',
+    '/fib',
+  ]);
+  const uri = pathname === null ? INVALID_URI : baseUrl + pathname;
+  request(uri, { json: true, timeout: 1000 }, (err, response) => {
+    // console.log(err, response && response.body && response.body.message);
+    // Start the next request sometime in the next second.
+    setTimeout(runRequestor, Math.random() * 1000);
+  });
+}
+
+const server = http.createServer(app);
+server.listen(port, () => {
+  console.log(`Server listening on ${baseUrl}`);
+
+  for (let i = 0; i < 40; ++i) {
+    setTimeout(runRequestor, i * 50);
+  }
+});

--- a/example/tracing/throws.js
+++ b/example/tracing/throws.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const tEnd = Date.now() + 150; // we want this to take 250ms
+
+while (Date.now() < tEnd) {
+  fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8');
+}
+
+fs.readFileSync(path.join(__dirname, '../../not-a-thing.json'), 'utf8');

--- a/lib/agents/profiler/index.js
+++ b/lib/agents/profiler/index.js
@@ -3,6 +3,8 @@
 const _ = require('lodash');
 const profiler = require('v8-profiler');
 
+const setSamplingInterval = require('bindings')('DebugThread').setSamplingInterval;
+
 const UrlMapper = require('../../url-mapper');
 
 const BaseAgent = require('../base');
@@ -48,8 +50,7 @@ class ProfilerAgent extends BaseAgent {
    * @param {integer} interval New sampling interval in microseconds.
    */
   setSamplingInterval(params) {
-    // TODO: Update FLAG_cpu_profiler_sampling_interval
-    this._ignore('setSamplingInterval', params);
+    setSamplingInterval(params.interval | 0);
   }
 
   _generateName() {

--- a/lib/agents/tracing/index.js
+++ b/lib/agents/tracing/index.js
@@ -21,8 +21,8 @@ class TracingAgent extends BaseAgent {
   }
 
   // Current tracing time in full microseconds
-  _getTime(startTime) {
-    const delta = startTime ? process.hrtime(startTime) : process.hrtime();
+  _getTime() {
+    const delta = process.hrtime();
     return Math.round(delta[0] * MICRO_PER_SECOND + delta[1] / NANO_PER_MICRO);
   }
 
@@ -96,8 +96,6 @@ class TracingAgent extends BaseAgent {
     clearInterval(this._measureTimer);
     this._measure();
     this._measureTimer = setInterval(this._measure.bind(this), MEASURE_EVERY_MS);
-
-    this._fakeStartTime = process.hrtime();
   }
 
   /**
@@ -110,7 +108,7 @@ class TracingAgent extends BaseAgent {
     this._buffer.push({
       pid: process.pid,
       tid: 1,
-      ts: this._getTime(),
+      ts: this._buffer[0].ts,
       ph: 'X',
       cat: 'devtools.timeline,v8',
       name: 'FunctionCall',
@@ -123,7 +121,7 @@ class TracingAgent extends BaseAgent {
           stackTrace: [],
         },
       },
-      dur: this._getTime(this._fakeStartTime),
+      dur: this._getTime() - this._buffer[0].ts,
     });
 
     this.emit('dataCollected', { value: this._buffer });

--- a/lib/agents/tracing/index.js
+++ b/lib/agents/tracing/index.js
@@ -21,8 +21,8 @@ class TracingAgent extends BaseAgent {
   }
 
   // Current tracing time in full microseconds
-  _getTime() {
-    const delta = process.hrtime();
+  _getTime(startTime) {
+    const delta = startTime ? process.hrtime(startTime) : process.hrtime();
     return Math.round(delta[0] * MICRO_PER_SECOND + delta[1] / NANO_PER_MICRO);
   }
 
@@ -96,6 +96,8 @@ class TracingAgent extends BaseAgent {
     clearInterval(this._measureTimer);
     this._measure();
     this._measureTimer = setInterval(this._measure.bind(this), MEASURE_EVERY_MS);
+
+    this._fakeStartTime = process.hrtime();
   }
 
   /**
@@ -104,6 +106,25 @@ class TracingAgent extends BaseAgent {
   end() {
     clearInterval(this._measureTimer);
     this._measureTimer = null;
+
+    this._buffer.push({
+      pid: process.pid,
+      tid: 1,
+      ts: this._getTime(),
+      ph: 'X',
+      cat: 'devtools.timeline,v8',
+      name: 'FunctionCall',
+      args: {
+        data: {
+          scriptId: '148',
+          scriptName: '',
+          scriptLine: 1,
+          frame: 'bugger-frame',
+          stackTrace: [],
+        },
+      },
+      dur: this._getTime(this._fakeStartTime),
+    });
 
     this.emit('dataCollected', { value: this._buffer });
     this._buffer = null;

--- a/lib/agents/tracing/index.js
+++ b/lib/agents/tracing/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const gcStats = require('gc-stats')();
+if (!process.addAsyncListener) require('async-listener');
+
+const makeStackTrace = require('../../url-mapper').makeStackTrace;
 
 const BaseAgent = require('../base');
 
@@ -17,7 +20,63 @@ class TracingAgent extends BaseAgent {
     this._buffer = null;
     this._measureTimer = null;
 
+    this._asyncListener = process.createAsyncListener({
+      before: this._asyncBefore.bind(this),
+      after: this._asyncAfter.bind(this),
+      error: this._asyncError.bind(this),
+    });
+    this._functionStack = [];
+
     gcStats.on('stats', stats => this._trackGC(stats));
+  }
+
+  _clearAsyncListener() {
+    process.removeAsyncListener(this._asyncListener);
+    this._functionStack = [];
+  }
+
+  _asyncBefore() {
+    if (!this._buffer) return;
+    // A FunctionCall started
+    const stackTrace = makeStackTrace(this._asyncListener.before);
+    // TODO: convert to args.data stuff
+    this._functionStack.push({
+      pid: process.pid,
+      tid: 1,
+      ts: this._getTime(),
+      ph: 'X',
+      cat: 'devtools.timeline,v8',
+      name: 'FunctionCall',
+      args: {
+        data: {
+          scriptId: '148',
+          scriptName: '',
+          scriptLine: 1,
+          frame: 'bugger-frame',
+          stackTrace: stackTrace,
+        },
+      },
+      dur: 0,
+    });
+  }
+
+  _asyncAfter() {
+    if (!this._buffer) return;
+    // A FunctionCall finished (pop?)
+    const top = this._functionStack.pop();
+    top.dur = this._getTime() - top.ts;
+    this._buffer.push(top);
+  }
+
+  _asyncError() {
+    if (!this._buffer) return;
+    // Execution failed, called instead of after (pop?)
+    this._functionStack.pop();
+  }
+
+  _setupAsyncListener() {
+    this._clearAsyncListener();
+    process.addAsyncListener(this._asyncListener);
   }
 
   // Current tracing time in full microseconds
@@ -78,13 +137,22 @@ class TracingAgent extends BaseAgent {
    * @param {string=} options Tracing options
    * @param {number=} bufferUsageReportingInterval If set, the agent will issue bufferUsage events at this interval, specified in milliseconds
    */
-  start(params) {
-    this._ignore('start', params);
+  start() {
+    this._setupAsyncListener();
     this._buffer = [
       {
         args: { sessionId: this._sessionId },
         cat: 'disabled-by-default-devtools.timeline',
         name: 'TracingStartedInPage',
+        ph: 'I',
+        pid: process.pid,
+        s: 'g',
+        tid: 1,
+        ts: this._getTime(),
+      },
+      {
+        cat: 'toplevel',
+        name: 'Fake::Event',
         ph: 'I',
         pid: process.pid,
         s: 'g',
@@ -102,27 +170,9 @@ class TracingAgent extends BaseAgent {
    * Stop trace events collection.
    */
   end() {
+    this._clearAsyncListener();
     clearInterval(this._measureTimer);
     this._measureTimer = null;
-
-    this._buffer.push({
-      pid: process.pid,
-      tid: 1,
-      ts: this._buffer[0].ts,
-      ph: 'X',
-      cat: 'devtools.timeline,v8',
-      name: 'FunctionCall',
-      args: {
-        data: {
-          scriptId: '148',
-          scriptName: '',
-          scriptLine: 1,
-          frame: 'bugger-frame',
-          stackTrace: [],
-        },
-      },
-      dur: this._getTime() - this._buffer[0].ts,
-    });
 
     this.emit('dataCollected', { value: this._buffer });
     this._buffer = null;

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "coffee-script": "^1.10.0",
     "eslint": "^1.9.0",
     "eslint-config-groupon": "^1.1.0",
+    "express": "^4.13.3",
     "request": "^2.65.0"
   },
   "dependencies": {
+    "async-listener": "^0.5.6",
     "bindings": "^1.2.1",
     "bluebird": "^2.9.34",
     "convert-source-map": "^1.1.2",

--- a/timeline.md
+++ b/timeline.md
@@ -1,10 +1,23 @@
-## The Timeline Tab
+# The Timeline Tab
 
 This documents tries to capture what data is shown in the timeline tab.
 
 ##### References
 
 * [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview)
+
+## The Flamechart
+
+### JSFrame
+
+*These are (or can be) extracted from a JavaScript profile.*
+
+JSFrame events will show up if:
+
+* They have a parent event.
+* The immediate parent is either a `FunctionCall` or `EvaluateScript`.
+
+## Events
 
 ### Duration Events
 

--- a/timeline.md
+++ b/timeline.md
@@ -1,0 +1,457 @@
+## The Timeline Tab
+
+This documents tries to capture what data is shown in the timeline tab.
+
+##### References
+
+* [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview)
+
+### Duration Events
+
+#### MajorGC / MinorGC
+
+Tracks time spent in GC.
+
+##### Arguments
+
+* `usedHeapSizeBefore`: *B only* Heap size before GC started.
+* `usedHeapSizeAfter`: *E only* Heap size after GC finished.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923138261202,
+  "ph": "B",
+  "cat": "devtools.timeline,v8",
+  "name": "MinorGC",
+  "args": {
+    "usedHeapSizeBefore": 21120128
+  },
+  "tts": 2617238
+}
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923138265640,
+  "ph": "E",
+  "cat": "devtools.timeline,v8",
+  "name": "MinorGC",
+  "args": {
+    "usedHeapSizeAfter": 19648456
+  },
+  "tts": 2621423
+}
+```
+
+### Complete Events
+
+#### FunctionCall
+
+Best guess: These are emitted whenever native code calls into JS-land.
+In blink this is handled via `V8ScriptRunner::callFunction`.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923135876376,
+  "ph": "X",
+  "cat": "devtools.timeline,v8",
+  "name": "FunctionCall",
+  "args": {
+    "data": {
+      "scriptId": "142",
+      "scriptName": "https://assets-cdn.github.com/assets/github-37bdbe413b8d63eb404649438916711bf73507e197a30398097bc716eaec7784.js",
+      "scriptLine": 5,
+      "frame": "0x1bb474a68240",
+      "stackTrace": [
+        {
+          "functionName": "a.onopen",
+          "scriptId": "142",
+          "url": "https://assets-cdn.github.com/assets/github-37bdbe413b8d63eb404649438916711bf73507e197a30398097bc716eaec7784.js",
+          "lineNumber": 5,
+          "columnNumber": 20099
+        }
+      ]
+    }
+  },
+  "dur": 61,
+  "tdur": 53,
+  "tts": 2521500
+}
+```
+
+### Instant Events
+
+#### TracingStartedInPage
+
+The very first trace event emitted.
+
+##### Arguments
+
+* `sessionId`: A unique id for the new tracing session.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923133809586,
+  "ph": "I",
+  "cat": "disabled-by-default-devtools.timeline",
+  "name": "TracingStartedInPage",
+  "args": {
+    "data": {
+      "sessionId": "46308.8",
+      "page": "0x1bb474a68240"
+    }
+  },
+  "tts": 1737318,
+  "s": "t"
+}
+```
+
+#### UpdateCounters
+
+The counters are updated and emitted "whenever something interesting happens".
+Maybe they are planning on using counter events for this in future..?
+
+##### Arguments
+
+* `data`: A map of counter name to value.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923138992351,
+  "ph": "I",
+  "cat": "disabled-by-default-devtools.timeline",
+  "name": "UpdateCounters",
+  "args": {
+    "data": {
+      "documents": 6,
+      "nodes": 9031,
+      "jsEventListeners": 31,
+      "jsHeapSizeUsed": 15926104
+    }
+  },
+  "tts": 2658770,
+  "s": "t"
+}
+```
+
+#### ResourceSendRequest
+
+##### Arguments
+
+* `data.requestId`: Identifier of the request.
+* `data.frame`: Identifier of the frame.
+* `data.url`: Url of the resource being requested.
+* `data.requestMethod`: HTTP method, e.g. 'POST' or 'GET'.
+* `data.stackTrace`: Originator of the request.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923137172974,
+  "ph": "I",
+  "cat": "devtools.timeline",
+  "name": "ResourceSendRequest",
+  "args": {
+    "data": {
+      "requestId": "46308.75",
+      "frame": "0x1bb474a68240",
+      "url": "https://api.github.com/_private/browser/stats",
+      "requestMethod": "POST",
+      "stackTrace": [
+        {
+          "functionName": "n",
+          "scriptId": "142",
+          "url": "https://assets-cdn.github.com/assets/github-37bdbe413b8d63eb404649438916711bf73507e197a30398097bc716eaec7784.js",
+          "lineNumber": 2,
+          "columnNumber": 7991
+        }
+      ]
+    }
+  },
+  "tts": 2602505,
+  "s": "t"
+}
+```
+
+#### ResourceReceiveResponse
+
+##### Arguments
+
+* `data.requestId`: Id of the request, matching the other events.
+* `data.frame`: Id of the loading frame.
+* `data.statusCode`: HTTP status code received from the remote server.
+* `data.mimeType`: Content type of the response entity.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923137730211,
+  "ph": "I",
+  "cat": "devtools.timeline",
+  "name": "ResourceReceiveResponse",
+  "args": {
+    "data": {
+      "requestId": "46308.75",
+      "frame": "0x1bb474a68240",
+      "statusCode": 200,
+      "mimeType": "application/json"
+    }
+  },
+  "tts": 2604816,
+  "s": "t"
+}
+```
+
+#### ResourceReceivedData
+
+##### Arguments
+
+* `data.requestId`: Guess..?
+* `data.frame`: Guess..?
+* `data.encodedDataLength`: Number of bytes received.
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923137730510,
+  "ph": "I",
+  "cat": "devtools.timeline",
+  "name": "ResourceReceivedData",
+  "args": {
+    "data": {
+      "requestId": "46308.75",
+      "frame": "0x1bb474a68240",
+      "encodedDataLength": 799
+    }
+  },
+  "tts": 2605051,
+  "s": "t"
+}
+```
+
+#### ResourceFinish
+
+##### Arguments
+
+* `data.requestId`: Same.
+* `data.didFail`: False unless the response could not be received.
+* `data.networkTime`: Looks like a timestamp..?
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 923137730848,
+  "ph": "I",
+  "cat": "devtools.timeline",
+  "name": "ResourceFinish",
+  "args": {
+    "data": {
+      "requestId": "46308.75",
+      "didFail": false,
+      "networkTime": 923137.730634
+    }
+  },
+  "tts": 2605234,
+  "s": "t"
+}
+```
+
+### Metadata Events
+
+#### num_cpus
+
+##### Example
+
+```json
+{
+  "pid": 46273,
+  "tid": 0,
+  "ts": 0,
+  "ph": "M",
+  "cat": "__metadata",
+  "name": "num_cpus",
+  "args": {
+    "number": 8
+  }
+}
+```
+
+#### process_labels
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 17187,
+  "ts": 0,
+  "ph": "M",
+  "cat": "__metadata",
+  "name": "process_labels",
+  "args": {
+    "labels": "request/request"
+  }
+}
+```
+
+#### process_name
+
+##### Example
+
+```json
+{
+  "pid": 46273,
+  "tid": 30539,
+  "ts": 0,
+  "ph": "M",
+  "cat": "__metadata",
+  "name": "process_name",
+  "args": {
+    "name": "Browser"
+  }
+}
+```
+
+#### process_sort_index
+
+##### Example
+
+```json
+{
+  "pid": 46273,
+  "tid": 30539,
+  "ts": 0,
+  "ph": "M",
+  "cat": "__metadata",
+  "name": "process_sort_index",
+  "args": {
+    "sort_index": -6
+  }
+}
+```
+
+#### thread_name
+
+##### Example
+
+```json
+{
+  "pid": 46325,
+  "tid": 24095,
+  "ts": 0,
+  "ph": "M",
+  "cat": "__metadata",
+  "name": "thread_name",
+  "args": {
+    "name": "HTMLParserThread"
+  }
+}
+```
+
+#### thread_sort_index
+
+##### Example
+
+```json
+{
+  "pid": 46308,
+  "tid": 1295,
+  "ts": 0,
+  "ph": "M",
+  "cat": "__metadata",
+  "name": "thread_sort_index",
+  "args": {
+    "sort_index": -1
+  }
+}
+```
+
+### Sample of Event Names (excluding `toplevel`)
+
+```bash
+  33 "ActivateLayerTree"
+2242 "AnalyzeTask"
+  86 "BeginFrame"
+  59 "BeginMainThreadFrame"
+   6 "CommitLoad"
+ 120 "CompositeLayers"
+   4 "Decode Image"
+   4 "Decode LazyPixelRef"
+  12 "Draw LazyPixelRef"
+  33 "DrawFrame"
+  56 "EvaluateScript"
+ 128 "EventDispatch"
+  30 "FireAnimationFrame"
+ 458 "FunctionCall"
+   2 "HitTest"
+   4 "ImageDecodeTask"
+  66 "InvalidateLayout"
+ 122 "Layout"
+  42 "MajorGC"
+  11 "MarkDOMContent"
+   6 "MarkLoad"
+  34 "MinorGC"
+  51 "NeedsBeginFrameChanged"
+  68 "Paint"
+  29 "PaintImage"
+   2 "ParseAuthorStyleSheet"
+  90 "ParseHTML"
+1573 "RasterTask"
+  31 "RequestAnimationFrame"
+  57 "RequestMainThreadFrame"
+  29 "ResourceFinish"
+  28 "ResourceReceiveResponse"
+ 115 "ResourceReceivedData"
+  29 "ResourceSendRequest"
+  58 "ScheduleStyleRecalculation"
+  21 "ScrollLayer"
+   1 "SetLayerTreeId"
+  38 "TimerFire"
+  39 "TimerInstall"
+  10 "TimerRemove"
+   1 "TracingStartedInPage"
+ 280 "UpdateCounters"
+ 127 "UpdateLayer"
+ 108 "UpdateLayerTree"
+ 116 "UpdateLayoutTree"
+   1 "WebSocketCreate"
+   1 "WebSocketDestroy"
+   1 "WebSocketReceiveHandshakeResponse"
+   1 "WebSocketSendHandshakeRequest"
+   1 "XHRLoad"
+   3 "XHRReadyStateChange"
+  18 "layerId"
+   3 "num_cpus"
+   1 "process_labels"
+   3 "process_name"
+   3 "process_sort_index"
+  43 "thread_name"
+   2 "thread_sort_index"
+```


### PR DESCRIPTION
- [x] Figure out how `JSFrame`, `JSSample`, and `FunctionCall` work together
- [x] Generate real `FunctionCall` events for all (or at least most) calls from cpp into JavaScript (via `async-listener`)
- [ ] Timer events (e.g. `setTimeout`) - maybe no longer needed given `async-listener` data
- [ ] `console.{time, timeEnd, timeStamp}` support
- [ ] Network requests
- [ ] Heap usage reporting tied to events, not to a timer

Fixes https://github.com/buggerjs/bugger/issues/47
