### PR TITLE
Better object subtype support

### DIFF
--- a/lib/agents/debugger/index.js
+++ b/lib/agents/debugger/index.js
@@ -527,13 +527,7 @@ class DebuggerAgent extends BaseAgent {
     }
 
     if (error) {
-      return {
-        result: ObjectGroup.add(params.objectGroup, error),
-        wasThrown: true,
-        exceptionDetails: {
-          text: error.message,
-        },
-      };
+      return ObjectGroup.exportException(params.objectGroup, error);
     }
 
     if (params.returnByValue) {

--- a/lib/agents/object-group.js
+++ b/lib/agents/object-group.js
@@ -17,6 +17,15 @@ function createRemoteObject(generatePreview, objectId, value) {
   if (Array.isArray(value) || Buffer.isBuffer(value)) {
     subtype = 'array';
     description += '[' + value.length + ']';
+  } else if (value instanceof Error) {
+    subtype = 'error';
+    description = value.stack;
+  } else if (value instanceof Date) {
+    subtype = 'date';
+    description = value.toString();
+  } else if (value instanceof RegExp) {
+    subtype = 'regexp';
+    description = value.toString();
   }
 
   const remoteObject = {
@@ -164,6 +173,18 @@ function addToObjectGroup(objectGroup, value, generatePreview) {
     _groups[objectGroup] = new ObjectGroup(objectGroup);
   }
   return _groups[objectGroup].add(value, generatePreview);
+};
+
+ObjectGroup.exportException =
+function exportException(objectGroup, error) {
+  return {
+    result: ObjectGroup.add(objectGroup, error),
+    wasThrown: true,
+    exceptionDetails: {
+      text: `Uncaught ${error.name} ${error.message}`,
+      // TODO: Figure out how to derive exception details
+    },
+  };
 };
 
 function parseAndGetByObjectId(objectId) {

--- a/lib/agents/runtime/index.js
+++ b/lib/agents/runtime/index.js
@@ -92,14 +92,8 @@ class RuntimeAgent extends BaseAgent {
         result: ObjectGroup.add(objectGroup, result, !!params.generatePreview),
         wasThrown: false,
       };
-    } catch (err) {
-      return {
-        result: { type: 'string', value: err.message },
-        wasThrown: true,
-        exceptionDetails: {
-          text: err.message,
-        },
-      };
+    } catch (error) {
+      return ObjectGroup.exportException(params.objectGroup, error);
     }
   }
 


### PR DESCRIPTION
This does not yet address the `exceptionDetails` field but I'm not sure if that's easily possible (it might involve some bigger changes to how `bugger` handles evaluation to make that part work). But it's close.

Fixes https://github.com/buggerjs/bugger/issues/71
Fixes https://github.com/buggerjs/bugger/issues/70